### PR TITLE
fix typo. dengerous -> dangerous

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 
 ## Basic Principles for Settings
 
-- Ban a dengerous style.
+- Ban a dangerous style.
 - Sort a style to avoid errors and to increase productivity.
 - We set rules as _error_ if we think such style causes mistake easily ABSOLUTELY.
-  - In other words, we make them an error that dengerous, foot-gun, or explicit mistake.
+  - In other words, we make them an error that dangerous, foot-gun, or explicit mistake.
 - We set rules as _warn_,  if we think such style might be ugly
   but it's useful for debugging or you might write when trying an approach.
   - You can land a patch without fixing warning. But YOU should fix them.


### PR DESCRIPTION
i found typo. please fix them.

```
$ git grep dengerous
README.md:- Ban a dengerous style.
README.md:  - In other words, we make them an error that dengerous, foot-gun, or explicit mistake.
```