### PR TITLE
Upgrade ESLint to v3.15

### DIFF
--- a/config/eslintrc_core.js
+++ b/config/eslintrc_core.js
@@ -329,6 +329,7 @@ module.exports = {
             'nonwords': false, // It's very tired to enforce before/after of `++`/`--`.
         }],
         'spaced-comment': 0,
+        'template-tag-spacing': 1,
         'unicode-bom': 2, // Ban byte-order-mark
         'wrap-regex': 0,
 

--- a/package.json
+++ b/package.json
@@ -19,14 +19,14 @@
   },
   "homepage": "https://github.com/voyagegroup/eslint-config-fluct",
   "peerDependencies": {
-    "eslint": "^3.14.0"
+    "eslint": "^3.15.0"
   },
   "optionalDependencies": {
     "eslint-plugin-node": "^3.0.3",
     "eslint-plugin-react": "^6.9.0"
   },
   "devDependencies": {
-    "eslint": "^3.14.0",
+    "eslint": "^3.15.0",
     "eslint-plugin-markdown": "^1.0.0-beta.3",
     "eslint-plugin-node": "^3.0.3",
     "eslint-plugin-react": "^6.9.0"


### PR DESCRIPTION
- This change enables http://eslint.org/docs/rules/template-tag-spacing.
- Fix https://github.com/voyagegroup/eslint-config-fluct/issues/69