### PR TITLE
Upgrade eslint-config-react to 6.10

### DIFF
--- a/config/eslintrc_react.js
+++ b/config/eslintrc_react.js
@@ -20,6 +20,10 @@ module.exports = {
     'rules': {
         'react/display-name': 0, // Auto covered by jsx transformer.
         'react/forbid-component-props': 1,
+        'react/forbid-elements': [1, {
+            'forbid': [],
+        }],
+        'react/forbid-foreign-prop-types': 2,
         'react/forbid-prop-types': 0,
         // The index of `Array<T>` is not suitable for `key` props.
         // But this restriction does not prevent that the id for each items is just a sequence number of some list
@@ -61,6 +65,7 @@ module.exports = {
             'component': true,
             'html': false,
         }],
+        'react/void-dom-elements-no-children': 1,
 
         // We define customized rules because we thought default settings mixes with
         // component's arguments and lifecycle methods.

--- a/package.json
+++ b/package.json
@@ -23,12 +23,12 @@
   },
   "optionalDependencies": {
     "eslint-plugin-node": "^4.0.1",
-    "eslint-plugin-react": "^6.9.0"
+    "eslint-plugin-react": "^6.10.0"
   },
   "devDependencies": {
     "eslint": "^3.15.0",
     "eslint-plugin-markdown": "^1.0.0-beta.3",
     "eslint-plugin-node": "^4.0.1",
-    "eslint-plugin-react": "^6.9.0"
+    "eslint-plugin-react": "^6.10.0"
   }
 }


### PR DESCRIPTION
Fix https://github.com/voyagegroup/eslint-config-fluct/issues/72

Release Note
-----------

https://github.com/yannickcr/eslint-plugin-react/releases

Enabled
-------

- https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/forbid-foreign-prop-types.md
- https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/void-dom-elements-no-children.md
- https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/forbid-elements.md
  - But the blacklist is empty.

No Touched
-----------

> Add `noSortAlphabetically` option to `jsx-sort-props`

We disabled `jsx-sort-props`.

> Add `when` option to `jsx-max-props-per-line`

We disabled `jsx-max-props-per-line`.