### PR TITLE
Disable node/no-hide-core-modules

### DIFF
--- a/config/eslintrc_node.js
+++ b/config/eslintrc_node.js
@@ -15,10 +15,24 @@ module.exports = {
     'rules': {
         'node/exports-style': [1, 'module.exports'],
         'node/no-deprecated-api': 2, // we'd like to detect the case of using deprecated apis.
-        'node/no-hide-core-modules': [1, {
+        // XXX:
+        // By these things, we disable this.
+        //
+        //  1. Some module linker (e.g. webpack) may add the node's stdlib polyfill to our dependencies
+        //     to work codes on web browsers.
+        //
+        //  2. Node.js' `require()` works as the following behavior (At least v7.7.1)
+        //      > Core modules are always preferentially loaded if their identifier is passed to require().
+        //      > For instance, require('http') will always return the built in HTTP module,
+        //      > even if there is a file by that name.
+        //      >
+        //      > https://nodejs.org/api/modules.html#modules_core_modules
+        //
+        //  3. In almost case, the application cannot ignore indirect dependencies.
+        'node/no-hide-core-modules': [0, {
             'allow': [],
             'ignoreDirectDependencies': false,
-            'ignoreIndirectDependencies': false,
+            'ignoreIndirectDependencies': true,
         }],
         'node/no-missing-import': 2,
         'node/no-missing-require': 2,


### PR DESCRIPTION
This rule has been introduced by https://github.com/voyagegroup/eslint-config-fluct/pull/76
However, by these things, we disable this.

  1. Some module linker (e.g. webpack) may add the node's stdlib polyfill to our dependencies
     to work codes on web browsers.
  2. Node.js' `require()` works as the following behavior (At least v7.7.1)
     > Core modules are always preferentially loaded if their identifier is passed to require().
     > For instance, require('http') will always return the built in HTTP module,
     > even if there is a file by that name.
     >
     > https://nodejs.org/api/modules.html#modules_core_modules
  3. In almost case, the application cannot ignore indirect dependencies.