### PR TITLE
Disable `require-await` rule.

### DIFF
--- a/config/eslintrc_core.js
+++ b/config/eslintrc_core.js
@@ -135,7 +135,7 @@ module.exports = {
             'allowEmptyReject': true, // Enable to create empty rejected one for compositing promises.
         }],
         'radix': 2, // Enforce 2nd argument of `parseInt()`.
-        'require-await': 1, // If there is no `await` in an async function, there is no reasons to make it async function.
+        'require-await': 0,
         'vars-on-top': 0, // This is a truly ridiculous convention.
         'wrap-iife': 0, // http://eslint.org/docs/rules/wrap-iife
         'yoda': 0, // http://eslint.org/docs/rules/wrap-iife


### PR DESCRIPTION
In a coding activity, async function is very useful syntax to intent to mark
that this function returns `Promise` even if there is no `await`.

So this should not be enabled in our rule set.