### PR TITLE
Drop Node v7 from TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ before_script:
 
 node_js:
   - "6"
-  - "7"
   - "node"
 
 notifications:


### PR DESCRIPTION
I discussed with @nekoya about #90 by the conversation, we reach these consensus.

- Drop Node v7 fromTravisCI.
   - This means our internal project will move to Node v8 in the not too distant future. 
   - Node v8 will be LTS. It's not aggressive motion. Rather it's pretty natural conservative approach.
   - By the same reason, we'll drop node v6 from our CI in near future.
- Even if we commit this change into `master`, this config would work with a projects which need to still use Node v7 without any problems.
   - Because we still have more lower testing target (Node v6).

## Related Issues

- Fix https://github.com/voyagegroup/eslint-config-fluct/issues/90