### PR TITLE
Update eslint-plugin-node

### DIFF
--- a/config/eslintrc_node.js
+++ b/config/eslintrc_node.js
@@ -15,6 +15,8 @@ module.exports = {
     'rules': {
         'node/exports-style': [1, 'module.exports'],
         'node/no-deprecated-api': 2, // we'd like to detect the case of using deprecated apis.
+        'node/no-extraneous-import': 2, // Specify more details in your project.
+        'node/no-extraneous-require': 2, // Specify more details in your project.
         'node/no-missing-import': 2,
         'node/no-missing-require': 2,
         'node/no-unpublished-bin': 0, // You should enable this rules if you develop a npm package.

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "eslint": "^4.0.0"
   },
   "optionalDependencies": {
-    "eslint-plugin-node": "^4.2.0",
+    "eslint-plugin-node": "^5.1.0",
     "eslint-plugin-react": "^7.1.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -193,14 +193,13 @@ eslint-plugin-markdown@^1.0.0-beta.3:
     remark-parse "^3.0.0"
     unified "^6.1.2"
 
-eslint-plugin-node@^4.2.0:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-4.2.2.tgz#82959ca9aed79fcbd28bb1b188d05cac04fb3363"
+eslint-plugin-node@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-5.1.0.tgz#bc8cdb85180d0b4d946a2531640e2a4dd7a4e6d4"
   dependencies:
-    ignore "^3.0.11"
-    minimatch "^3.0.2"
-    object-assign "^4.0.1"
-    resolve "^1.1.7"
+    ignore "^3.3.3"
+    minimatch "^3.0.4"
+    resolve "^1.3.3"
     semver "5.3.0"
 
 eslint-plugin-react@^7.1.0:
@@ -393,7 +392,7 @@ iconv-lite@^0.4.17:
   version "0.4.18"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.18.tgz#23d8656b16aae6742ac29732ea8f0336a4789cf2"
 
-ignore@^3.0.11, ignore@^3.3.3:
+ignore@^3.3.3:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.3.tgz#432352e57accd87ab3110e82d3fea0e47812156d"
 
@@ -565,7 +564,7 @@ mimic-fn@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.1.0.tgz#e667783d92e89dbd342818b5230b9d62a672ad18"
 
-minimatch@^3.0.2, minimatch@^3.0.4:
+minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
@@ -729,7 +728,7 @@ resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
 
-resolve@^1.1.7:
+resolve@^1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.3.3.tgz#655907c3469a8680dc2de3a275a8fdd69691f0e5"
   dependencies:


### PR DESCRIPTION
Fixed: #92 

`no-unpublish-import` `no-unpublish-require` から
`no-extraneous-import` `no-extraneous-require` が派生したので追加

`no-unsupported-features` がnode v8に対応したらしい
nishikiでためしたら
`Import and export declarations are not supported yet on Node 8.0.0`
で怒られた多発してうーんってなった。
`eslintrc_node.js` のコメントには

> 'node/no-unsupported-features': 0, // Covered by core's `no-restricted-syntax

ってことなのでとりあえず現状でいっかみたいになりました。

