### PR TITLE
Update the react version to v16 that we used for 'react/no-deprecated'.

### DIFF
--- a/config/eslintrc_react.js
+++ b/config/eslintrc_react.js
@@ -11,7 +11,7 @@ module.exports = {
 
     'settings': {
         'react': {
-            'version': '15.5', // used for 'no-deprecated' rule.
+            'version': '16.0', // used for 'no-deprecated' rule.
         }
     },
 


### PR DESCRIPTION
[React v16 has been released](https://facebook.github.io/react/blog/2017/09/26/react-v16.0.html).

React v16 contains many internal changes for future releases.

As an ideal ruleset, we should specify it as "recommended".
If user does not use v16, then they can override this config in their
project side!