### PR TITLE
Enable argsIgnorePattern for no-unused-vars

### DIFF
--- a/config/eslintrc_core.js
+++ b/config/eslintrc_core.js
@@ -161,6 +161,7 @@ module.exports = {
         'no-unused-vars': [1, { // Not make an error for debugging.
             'vars': 'all',
             'args': 'after-used',
+            'argsIgnorePattern': '^_', // Sort with TypeScript compiler's builtin linter.            
             'caughtErrors': 'all',
             'caughtErrorsIgnorePattern': '^_', // Allow `catch (_e) {...}`
         }],


### PR DESCRIPTION
We should sort it with TypeScript compiler's builtin linter.