### PR TITLE
Remove unused preferType option from valid-jsdoc

### DIFF
--- a/config/eslintrc_core.js
+++ b/config/eslintrc_core.js
@@ -49,12 +49,6 @@ module.exports = {
             'requireReturn': true,
             'requireParamDescription': false,
             'requireReturnDescription': false,
-            //'preferType': {
-            //    'Boolean': 'boolean',
-            //    'Number': 'number',
-            //    'String': 'string',
-            //    'object': 'Object',
-            //},
         }],
         'valid-typeof': [1, {'requireStringLiterals': true}],
 


### PR DESCRIPTION
Strictly, `String` and other CamelCased primitive types is different from `string` and other primitive types.

`String` is the wrapper object and `s` generated by `s = String('bar')`, would be `(typeof s === 'object') === true`. Other wrapper objects behaves similarly.

And tsc v2.6 or later with `--strict` option can detect this pitfall. So I think we should not enforce `preferType`. It's not convinient as the convention used with tsc's `--checkJs` option.

If you think this digs a new pitfall instead. But it's needless fears. We don't use this option for a long time. This commit is just a cleanup.

## See also

- https://eslint.org/docs/rules/