### PR TITLE
Add parserOptions explicitly for this project

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,6 +16,13 @@ module.exports = {
         './config/eslintrc_react.js',
     ],
 
+    // This option is only applied to this project
+    // (This will not be applied for an user project).
+    'parserOptions': {
+        'ecmaVersion': 6,
+        'sourceType': 'script',
+    },
+
     'plugins': [
         'markdown',
     ],


### PR DESCRIPTION
- This allow to write ES2015 syntax (`let`, `const`, or others) in this repository.
- Node.js v6 almost support ES2015 syntactic features. So this would not cause the problem which ESLint says ok but Node.js v6 says some error on the run-time.