### PR TITLE
Update ESLint v4.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "eslint-plugin-react": "^7.5.1"
   },
   "devDependencies": {
-    "eslint": "^4.16.0",
+    "eslint": "^4.17.0",
     "eslint-plugin-markdown": "^1.0.0-beta.7",
     "eslint-plugin-node": "^5.2.0",
     "eslint-plugin-react": "^7.5.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -309,9 +309,9 @@ eslint-visitor-keys@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
 
-eslint@^4.16.0:
-  version "4.16.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.16.0.tgz#934ada9e98715e1d7bbfd6f6f0519ed2fab35cc1"
+eslint@^4.17.0:
+  version "4.17.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.17.0.tgz#dc24bb51ede48df629be7031c71d9dc0ee4f3ddf"
   dependencies:
     ajv "^5.3.0"
     babel-code-frame "^6.22.0"


### PR DESCRIPTION
Changelog
----------

https://eslint.org/blog/2018/02/eslint-v4.17.0-released

Detailed
------------------

This does not introduce any new options.

> A new multiline option has been added to the padding-line-between-statements rule.

We're enabling [this rule](https://eslint.org/docs/rules/padding-line-between-statements),
but it only sort a directive part.

I don't feel we need add new `multiline` option to it.

Why not update `peerDependencies`?
----------------------------------

This version up does not include any newly introduced features.
I think we don't have to update its field.

## Related Issue

- Fix https://github.com/voyagegroup/eslint-config-fluct/issues/126