### PR TITLE
Update eslint-plugin-react to v7.7

### DIFF
--- a/config/eslintrc_react.js
+++ b/config/eslintrc_react.js
@@ -29,7 +29,9 @@ module.exports = {
         'react/forbid-elements': [1, {
             'forbid': [],
         }],
-        'react/forbid-foreign-prop-types': 2,
+        'react/forbid-foreign-prop-types': [2, {
+            'allowInPropTypes': false, // We doubt this option is really useful.
+        }],
         'react/forbid-prop-types': 0,
         'react/no-access-state-in-setstate': 1,
         // The index of `Array<T>` is not suitable for `key` props.
@@ -132,6 +134,7 @@ module.exports = {
         'react/jsx-indent': [1, 4], // Sort with core's `indent` rule.
         'react/jsx-indent-props': 0, // we cannot force alphabetical order to our old codebase, and this is not any serious problem.
         'react/jsx-key': 1,
+        'react/jsx-max-depth': 0, // We should not restrict this by default.
         'react/jsx-max-props-per-line': 0, // we don't think this is serious problem.
         'react/jsx-no-bind': [2, { // Sort to bind with this in constructor.
             'ignoreRefs': true, // we may use `refs`.

--- a/package.json
+++ b/package.json
@@ -23,12 +23,12 @@
   },
   "optionalDependencies": {
     "eslint-plugin-node": "^5.2.0",
-    "eslint-plugin-react": "^7.6.1"
+    "eslint-plugin-react": "^7.7.0"
   },
   "devDependencies": {
     "eslint": "^4.18.0",
     "eslint-plugin-markdown": "^1.0.0-beta.7",
     "eslint-plugin-node": "^5.2.0",
-    "eslint-plugin-react": "^7.6.1"
+    "eslint-plugin-react": "^7.7.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -289,9 +289,9 @@ eslint-plugin-node@^5.2.0:
     resolve "^1.3.3"
     semver "5.3.0"
 
-eslint-plugin-react@^7.6.1:
-  version "7.6.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.6.1.tgz#5d0e908be599f0c02fbf4eef0c7ed6f29dff7633"
+eslint-plugin-react@^7.7.0:
+  version "7.7.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.7.0.tgz#f606c719dbd8a1a2b3d25c16299813878cca0160"
   dependencies:
     doctrine "^2.0.2"
     has "^1.0.1"


### PR DESCRIPTION
Release Note
------------------

https://github.com/yannickcr/eslint-plugin-react/releases/tag/v7.7.0

Detailed Changes
--------------------

- Disable `allowInPropTypes` option for `forbid-foreign-prop-types`.
  - I doubt this option is really useful.
  - I doubt this type reusing which this option allows is really useful.
- Disable `jsx-max-depth`.
  - I think this option is similar to [ESLint's complexity rule](https://eslint.org/docs/rules/complexity).