### PR TITLE
Disable react/jsx-first-prop-new-line

### DIFF
--- a/config/eslintrc_react.js
+++ b/config/eslintrc_react.js
@@ -126,7 +126,7 @@ module.exports = {
         'react/jsx-filename-extension': [2, {
             'extensions': ['.jsx']
         }],
-        'react/jsx-first-prop-new-line': [1, 'never'],
+        'react/jsx-first-prop-new-line': 0, // This is just stylistic issue.
         'react/jsx-handler-names': [2, {
             'eventHandlerPrefix': 'on', // There is no event handler which is diffrent from this rules (`onBarFoo`).
             'eventHandlerPropPrefix': 'on',


### PR DESCRIPTION
This is not a breaking change because this does not change the warning.

Motivation
------------

This rule is enabled by me in https://github.com/voyagegroup/eslint-config-fluct/issues/33
However, this was my mistake. In a real world, we face the case of that
we'd like to take both form of these:

```javascript
// style 1
<a href={href} className={...}>{'some link'}</a>

// style 2
<a href={href}
  className={...}
>
  {'some link'}
</a>

// style 3
<a
  href={href}
  className={...}
>
  {'some link'}
</a>
```

So this change disable `react/jsx-first-prop-new-line` as it is just a stylistic issue.