### PR TITLE
Update ESLint to v5.2

### DIFF
--- a/config/eslintrc_core.js
+++ b/config/eslintrc_core.js
@@ -146,7 +146,6 @@ module.exports = {
 
         // Variables
         'init-declarations': [2, 'always'],
-        'no-catch-shadow': 2, // https://eslint.org/docs/rules/no-catch-shadow
         'no-delete-var': 2, // In a general case, we don't have to do this.
         'no-label-var': 2,
         'no-restricted-globals' : [2, // https://eslint.org/docs/rules/no-restricted-globals

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "eslint-plugin-react": "^7.10.0"
   },
   "devDependencies": {
-    "eslint": "^5.1.0",
+    "eslint": "^5.2.0",
     "eslint-plugin-markdown": "^1.0.0-beta.8",
     "eslint-plugin-node": "^6.0.1",
     "eslint-plugin-react": "^7.10.0"

--- a/package.json
+++ b/package.json
@@ -19,14 +19,14 @@
   },
   "homepage": "https://github.com/voyagegroup/eslint-config-fluct",
   "peerDependencies": {
-    "eslint": "^5.0.1"
+    "eslint": "^5.1.0"
   },
   "optionalDependencies": {
     "eslint-plugin-node": "^6.0.1",
     "eslint-plugin-react": "^7.10.0"
   },
   "devDependencies": {
-    "eslint": "^5.0.1",
+    "eslint": "^5.1.0",
     "eslint-plugin-markdown": "^1.0.0-beta.8",
     "eslint-plugin-node": "^6.0.1",
     "eslint-plugin-react": "^7.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -273,13 +273,17 @@ eslint-scope@^4.0.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
+eslint-utils@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.3.1.tgz#9a851ba89ee7c460346f97cf8939c7298827e512"
+
 eslint-visitor-keys@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
 
-eslint@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.0.1.tgz#109b90ab7f7a736f54e0f341c8bb9d09777494c3"
+eslint@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.2.0.tgz#3901ae249195d473e633c4acbc370068b1c964dc"
   dependencies:
     ajv "^6.5.0"
     babel-code-frame "^6.26.0"
@@ -288,6 +292,7 @@ eslint@^5.0.1:
     debug "^3.1.0"
     doctrine "^2.1.0"
     eslint-scope "^4.0.0"
+    eslint-utils "^1.3.1"
     eslint-visitor-keys "^1.0.0"
     espree "^4.0.0"
     esquery "^1.0.1"
@@ -295,8 +300,8 @@ eslint@^5.0.1:
     file-entry-cache "^2.0.0"
     functional-red-black-tree "^1.0.1"
     glob "^7.1.2"
-    globals "^11.5.0"
-    ignore "^3.3.3"
+    globals "^11.7.0"
+    ignore "^4.0.2"
     imurmurhash "^0.1.4"
     inquirer "^5.2.0"
     is-resolvable "^1.1.0"
@@ -424,7 +429,7 @@ glob@^7.0.3, glob@^7.0.5, glob@^7.1.2:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-globals@^11.5.0:
+globals@^11.7.0:
   version "11.7.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.7.0.tgz#a583faa43055b1aca771914bf68258e2fc125673"
 
@@ -469,9 +474,13 @@ iconv-lite@^0.4.17:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-ignore@^3.3.3, ignore@^3.3.6:
+ignore@^3.3.6:
   version "3.3.10"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
+
+ignore@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.2.tgz#0a8dd228947ec78c2d7f736b1642a9f7317c1905"
 
 imurmurhash@^0.1.4:
   version "0.1.4"


### PR DESCRIPTION
## Update ESLint to v5.1

* https://eslint.org/blog/2018/07/eslint-v5.1.0-released
* `no-catch-shadow` has been deprecated.
    * So I remove it.

## Update ESLint to v5.2

* https://eslint.org/blog/2018/07/eslint-v5.2.0-released
* There is no changes which we should update `peerDependencies`.