### PR TITLE
Relax to use .setState()

### DIFF
--- a/config/eslintrc_react.js
+++ b/config/eslintrc_react.js
@@ -50,7 +50,7 @@ module.exports = {
         'react/no-multi-comp': 0, // Enable to define a multiple component to a single file.
         'react/no-render-return-value': 2,
         'react/no-redundant-should-component-update': 1,
-        'react/no-set-state': 1, // Recommend to use props instead of `setState()`.
+        'react/no-set-state': 0,
         'react/no-string-refs': 2,
         'react/no-this-in-sfc': 1,
         'react/no-typos': 0,


### PR DESCRIPTION
This restriction was my mistake.

We should prefer `.props` than `.state` in React.
But `.setState()` is a part of React and it would not be a right to restrict `.setState()` for creating a complex component.

I agree that we should avoid the complexity in view (React) area,
but I also think we catch them in a code review process or a design phase before coding.