### PR TITLE
Remove `saneyuki` (my previous name) from OWNERS.json

### DIFF
--- a/OWNERS.json
+++ b/OWNERS.json
@@ -3,8 +3,7 @@
   "reviewers": [
     "himu62",
     "kanufy",
-    "nekoya",
-    "saneyuki"
+    "nekoya"
   ],
   "auto_merge.enabled": true,
   "auto_merge.delete_branch": true


### PR DESCRIPTION
I renamed my github id, and I would not have enough time to contribute to this repository. So I think it's most reasonable way to remove my name from OWNERS.json.